### PR TITLE
Update eliza1.lisp

### DIFF
--- a/lisp/eliza1.lisp
+++ b/lisp/eliza1.lisp
@@ -8,6 +8,11 @@
 
 ;; New version of pat-match with segment variables
 
+(defconstant fail nil "Indicates pat-match failure")
+
+(defconstant no-bindings '((t . t))
+  "Indicates pat-match success, with no variables.")
+
 (defun variable-p (x)
   "Is x a variable (a symbol beginning with `?')?"
   (and (symbolp x) (equal (elt (symbol-name x) 0) #\?)))


### PR DESCRIPTION
The constants for "fail" and "no-bindings" are defined nowhere in the individual chapter files, making those files incomplete. These definitions exist in "auxfns.lisp"